### PR TITLE
Kafka listener not starting

### DIFF
--- a/remote_event_bundle/bundle.py
+++ b/remote_event_bundle/bundle.py
@@ -1,6 +1,6 @@
 from .event import RemoteEvent
 import inject
-from applauncher.kernel import Configuration, InjectorReadyEvent, KernelShutdownEvent
+from applauncher.kernel import Configuration, KernelReadyEvent, KernelShutdownEvent
 import logging
 import importlib
 
@@ -18,16 +18,16 @@ class RemoteEventBundle(object):
         }
 
         self.event_listeners = [
-            (InjectorReadyEvent, self.injector_ready),
             (RemoteEvent, self.propagate_remote_event),
-            (KernelShutdownEvent, self.kernel_shutdown)
+            (KernelReadyEvent, self.kernel_ready),
+            (KernelShutdownEvent, self.kernel_shutdown),
         ]
 
         self.run = True
         self.backend = None
 
     @inject.params(config=Configuration)
-    def injector_ready(self, event, config):
+    def kernel_ready(self, event, config):
         backend_module = importlib.import_module(f'remote_event_bundle.backend.{config.remote_event.backend}_backend')
         backend = getattr(backend_module, f"{config.remote_event.backend.capitalize()}Backend")
         self.backend = backend(group_id=config.remote_event.group_id)

--- a/remote_event_bundle/bundle.py
+++ b/remote_event_bundle/bundle.py
@@ -1,8 +1,10 @@
-from .event import RemoteEvent
-import inject
-from applauncher.kernel import Configuration, KernelReadyEvent, KernelShutdownEvent
 import logging
 import importlib
+
+import inject
+from applauncher.kernel import Configuration, KernelReadyEvent, KernelShutdownEvent
+
+from .event import RemoteEvent
 
 
 class RemoteEventBundle(object):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('requirements.txt') as fp:
 setup(
     name='remote_event_bundle',
     packages=find_packages(),
-    version='1.6',
+    version='1.7',
     description='Remote events support for applauncher',
     author='Alvaro Garcia Gomez',
     author_email='maxpowel@gmail.com',


### PR DESCRIPTION
@maxpowel For the reasons described in https://github.com/applauncher-team/remote_event_bundle/issues/2 this Pull Request changes the registering of events to be run after KernelReadyEvent instead of InjectorReadyEvent.
