### PR TITLE
Set event name to kafka topic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "remote_event_bundle"
-version = "2.0.2"
+version = "2.1.0"
 description = "Remote events"
 authors = ["Alvaro Garcia <maxpowel@gmail.com>"]
 license = "Apache"

--- a/remote_event_bundle/backend/kafka_backend.py
+++ b/remote_event_bundle/backend/kafka_backend.py
@@ -42,6 +42,7 @@ def dispatch_event(message):
     try:
         event = Event()
         event.__dict__ = json.loads(message.value())
+        event.event_name = message.topic()
         headers = message.headers()
         signals = []
         if headers:
@@ -51,9 +52,9 @@ def dispatch_event(message):
         if signals:
             event._signals = signals
         else:
-            event._signals = [message.topic()]
+            event._signals = [event.event_name]  # Which will have the value of message.topic()
 
-        event._propagated = True
+        event._propagated = True        
         ServiceContainer.event_manager().dispatch(event)
     except Exception as e:
         logger.error(str(e))

--- a/remote_event_bundle/backend/kafka_backend.py
+++ b/remote_event_bundle/backend/kafka_backend.py
@@ -54,7 +54,7 @@ def dispatch_event(message):
         else:
             event._signals = [event.event_name]  # Which will have the value of message.topic()
 
-        event._propagated = True        
+        event._propagated = True
         ServiceContainer.event_manager().dispatch(event)
     except Exception as e:
         logger.error(str(e))


### PR DESCRIPTION
Since having the right event class to instantiate when dispatching the event might not be easy (classes are not restricted to the ones provided by this package), the least we can do is set the event_name to the EventClass.event_name attribute. For kafka, it is the same as the message's topic.